### PR TITLE
Prevent users from getting environment variables

### DIFF
--- a/lib/sicuro/base.rb
+++ b/lib/sicuro/base.rb
@@ -136,7 +136,8 @@ module Sicuro
     
     begin
       output_io = $stdout = $stderr = StringIO.new
-      code = '$SAFE = 3; BEGIN { $SAFE=3 };' + code
+      remove_env = "Object.class_eval { remove_const :ENV };"
+      code = remove_env + '$SAFE = 3; BEGIN { $SAFE=3 };' + code
       
       result = ::Kernel.eval(code, TOPLEVEL_BINDING)
     rescue Exception => e


### PR DESCRIPTION
Rubeque got hacked by someone basically calling "puts ENV" inside Sicuro.eval. This pull request should prevent that from happening by unsetting ENV inside the Sicuro eval process. I am not sure if I put it in the right place so let me know if I need to change that. Also, I should probably also check for any other constants that Ruby automatically sets as well. Thanks!
