### PR TITLE
Fixed removal of unsafe Kernel methods

### DIFF
--- a/test/sicuro_test.rb
+++ b/test/sicuro_test.rb
@@ -2,22 +2,22 @@ require 'teststrap'
 
 context 'Sicuro - ' do
   setup { s = Sicuro.new; s.setup; s }
-  
+
   context 'printing text' do
     asserts(:eval_value, 'puts "hi"').equals("hi\n")
   end
-  
+
   context 'return value' do
     asserts(:eval_value, '"hi"').equals('"hi"')
     asserts(:eval_value, "'hi'").equals('"hi"')
     asserts(:eval_value, '1'   ).equals('1')
     asserts(:eval_value, 'fail').equals('RuntimeError: ')
   end
-  
+
   context 'libs' do
     asserts(:eval_value, 'Set', ['set']).equals('"Set"')
   end
-  
+
   context 'precode' do
     asserts(:eval_value, 'Set', nil, 'require "set"').equals('"Set"')
   end
@@ -29,36 +29,40 @@ context 'Sicuro - ' do
     asserts(:eval_exception, 'raise').equals('RuntimeError: ')
     asserts(:eval_inspect, '1').equals('#<Sicuro::Eval stdin="1" value="1">')
   end
-  
+
   context 'exceptions' do
     asserts(:eval_exception, 'undefined').equals("NameError: undefined local variable or method `undefined' for main:Object")
-    asserts(:eval_exception, ':').equals("SyntaxError: <main>:4: syntax error, unexpected $end, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END\n      }; :\n          ^")
+    asserts(:eval_exception, ':').equals("SyntaxError: <main>:5: syntax error, unexpected $end, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END\n      }; :\n          ^")
     asserts(:eval_exception, 'a=[];loop{a<<a}').equals("NoMemoryError: failed to allocate memory")
   end
-  
+
   context 'timed-out code returns proper string' do
     asserts(:eval_value, 'sleep 6').equals('Timeout::Error: Code took longer than 5 seconds to terminate.')
-    
+
     # The following crashed many safe eval systems, including many versions of
     # rubino, where sicuro was pulled from.
     asserts(:eval_value, 'def Exception.to_s;loop{};end;loop{}').equals('Timeout::Error: Code took longer than 5 seconds to terminate.')
-    
+
     # The following used to create an endlessly-hanging process. Not sure how to
     # check for that automatically, but giving 'Timeout::Error: Code took longer than 5 seconds to terminate.' is a bit closer
     # than hanging endlessly.
     asserts(:eval_value, 'sleep').equals('Timeout::Error: Code took longer than 5 seconds to terminate.')
   end
-  
+
   context 'timed-out code properly terminated' do
     asserts(:eval_running?, 'sleep 6').equals(false)
-    
+
     # The following crashed many safe eval systems, including many versions of
     # rubino, where sicuro was pulled from.
     asserts(:eval_running?, 'def Exception.to_s;loop{};end;loop{}').equals(false)
-    
+
     # The following used to create an endlessly-hanging process. Not sure how to
     # check for that automatically, but giving 'Timeout::Error: Code took longer than 5 seconds to terminate.' is a bit closer
     # than hanging endlessly.
     asserts(:eval_running?, 'sleep').equals(false)
+  end
+
+  context 'unsafe Kernel methods are removed' do
+    asserts(:eval_exception, "Kernel.open('.')").equals("NoMethodError: undefined method `open' for Kernel:Module")
   end
 end


### PR DESCRIPTION
Hi,

The removal of Kernel methods as implemented in `#_unsafe_eval` has no effect, as undefining them with `#undef_method` is not enough. 

This means that we can run code like this:

```
Sicuro.eval "Kernel.open('foo', 'w') { |f| f.write 'bar' }"
```

This is especially dangerous because the latest version of FakeFS fails to fake `Kernel.open` and, consequently, the code above creates an actual file on the filesystem (unless $SAFE is used, of course).

Because of the way Kernel is defined, the unsafe methods have to be removed with `#remove_method` from both Kernel and Kernel's eigenclass:

```
Kernel.send(:remove_method, x.to_sym)
class << Kernel; self end.send(:remove_method, x.to_sym)
```

This pull request fixes the issue in `#_unsafe_eval` and adds the corresponding test.

Tested with Ruby 1.8.7, 1.9.2 and 1.9.3 on MacOS 10.6.8 and Ubuntu 12.04.

Thanks,
_Luca Bernardo Ciddio_
